### PR TITLE
main/readme: pinned this version to gcp 2.X.X

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Creates DC/OS Bootstrap intance
 ```hcl
 module "bootstraps" {
   source = "dcos-terraform/instances/gcp"
-  version = "~> 0.1.0"
+  version = "~> 0.2.0"
 
   num_instance                   = "${var.instances_count}"
   disk_size                      = "${var.gcp_instances_disk_size}"

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@
  *```hcl
  * module "bootstraps" {
  *   source = "dcos-terraform/instances/gcp"
- *   version = "~> 0.1.0"
+ *   version = "~> 0.2.0"
  *
  *   num_instance                   = "${var.instances_count}"
  *   disk_size                      = "${var.gcp_instances_disk_size}"
@@ -27,11 +27,13 @@
  *```
  */
 
-provider "google" {}
+provider "google" {
+  version = "~> 2.0"
+}
 
 module "dcos-bootstrap-instances" {
   source  = "dcos-terraform/instance/gcp"
-  version = "~> 0.1.0"
+  version = "~> 0.2.0"
 
   providers = {
     google = "google"


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS-48802

As GCP update the latest version of the provider, we now require to update the templates so that it can select the proper version associated with the change.