### PR TITLE
Change modules to use google-beta provider

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -27,14 +27,14 @@
  *```
  */
 
-provider "google" {}
+provider "google-beta" {}
 
 module "dcos-bootstrap-instances" {
   source  = "dcos-terraform/instance/gcp"
   version = "~> 0.1.0"
 
   providers = {
-    google = "google"
+    google-beta = "google-beta"
   }
 
   cluster_name             = "${var.cluster_name}"


### PR DESCRIPTION
In order to not require pinning to an older version of the terraform provider (dcos-terraform/terraform-gcp-dcos#24) the options appear to be 1) remove usage of beta features or 2) move to the google-beta provider. This PR is an attempt at option 2.